### PR TITLE
Add fast binary to test download speeds

### DIFF
--- a/fast/Dockerfile
+++ b/fast/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+MAINTAINER Mark Myers <marcusmyers@gmail.com>
+RUN apk add --update curl \
+      ca-certificates \
+    && rm -rf /var/cache/apk/*
+
+RUN curl -L https://github.com/ddo/fast/releases/download/v0.0.1/fast_linux_386 -o /usr/local/bin/fast \
+    && chmod a+x /usr/local/bin/fast
+
+CMD [ "/usr/local/bin/fast" ]


### PR DESCRIPTION
This commit adds a `Dockerfile` to test download speeds using the `fast`
binary.