### PR TITLE
Add laravel image

### DIFF
--- a/laravel/Dockerfile
+++ b/laravel/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:7.0.9-alpine
+MAINTAINER Mark Myers <marcusmyers@gmail.com>
+
+RUN apk add --update tzdata \
+  && cp /usr/share/zoneinfo/America/New_York /etc/localtime \
+  && echo "America/New_York" >  /etc/timezone \
+  && apk del tzdata \
+  && rm -rf /var/cache/apk/*
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+  && php -r "unlink('composer-setup.php');"
+
+RUN mkdir /app
+WORKDIR /app


### PR DESCRIPTION
This commit adds a laravel dockerfile to be used for a dev-base. The
image is based off of `php:7.0.9-alpine`.