### PR TITLE
Update to php 7.1 alpine image

### DIFF
--- a/laravel/Dockerfile
+++ b/laravel/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0.9-alpine
+FROM php:7.1-alpine
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 RUN apk add --update tzdata \


### PR DESCRIPTION
In order to use the latest version of php this commit use the
`php:7.1-alpine` image as a base image.