### PR TITLE
Add composer image with tagged version 1.4.1

### DIFF
--- a/composer/1.4.1/Dockerfile
+++ b/composer/1.4.1/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:7.1-alpine
+MAINTAINER Mark Myers <marcusmyers@gmail.com>
+
+ADD https://getcomposer.org/download/1.4.1/composer.phar /usr/local/bin/
+
+RUN apk add --update tzdata freetype-dev libjpeg-turbo-dev libpng-dev libmcrypt-dev \
+  && cp /usr/share/zoneinfo/America/New_York /etc/localtime \
+  && echo "America/New_York" >  /etc/timezone \
+  && mv /usr/local/bin/composer.phar /usr/local/bin/composer \
+  && apk del tzdata \
+  && rm -rf /var/cache/apk/*

--- a/laravel/Dockerfile
+++ b/laravel/Dockerfile
@@ -1,15 +1,5 @@
-FROM php:7.1-alpine
+FROM marcusmyers/composer:1.4.1
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
-
-RUN apk add --update tzdata freetype-dev libjpeg-turbo-dev libpng-dev libmcrypt-dev \
-  && cp /usr/share/zoneinfo/America/New_York /etc/localtime \
-  && echo "America/New_York" >  /etc/timezone \
-  && apk del tzdata \
-  && rm -rf /var/cache/apk/*
-
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
-  && php -r "unlink('composer-setup.php');"
 
 RUN docker-php-ext-install gd mbstring mysqli pdo pdo_mysql mcrypt
 


### PR DESCRIPTION
This commit adds a `Dockerfile` for composer version 1.4.1 and updates
where the laravel image builds from, `marcusmyers/composer:1.4.1`