### PR TITLE
Add latest version version of unifi controller

### DIFF
--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -13,9 +13,13 @@ RUN apt-get update && \
       curl \
       unzip \
       locales \
+      tzdata \
       vim && \
       apt-get -q clean && \
       rm -rf /var/lib/apt/lists/* && \
-    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+    ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime && \
+    dpkg-reconfigure --frontend noninteractive tzdata
 
-ENV LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.utf8

--- a/unifi/5.4.15/Dockerfile
+++ b/unifi/5.4.15/Dockerfile
@@ -5,13 +5,24 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv C0A52C50
 
 RUN echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" >> /etc/apt/sources.list.d/200-unifi.list
 
-ENV JAVA_MAX_HEAP_SIZE 512M
+ENV UNIFI_INSTALL_URL=http://dl.ubnt.com/unifi/5.4.15/unifi_sysvinit_all.deb \
+    JAVA_MAX_HEAP_SIZE 512M
 
 # Install Supporting Packages
 RUN apt-get -q update && \
-  apt-get install -qy --force-yes unifi && \
+  apt-get install -qy --force-yes \
+    prelink \
+    mongodb-server \
+    binutils \
+    jsvc \
+    openjdk-8-jre \
+    openjdk-8-jre-headlessi && \
   apt-get -q clean && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  curl -L -o unifi_sysvinit_all.deb $UNIFI_INSTALL_URL && \
+  dpkg -i unifi_sysvinit_all.deb && \
+  execstack -c /usr/lib/unifi/lib/native/Linux/amd64/libubnt_webrtc_jni.so && \
+  rm unifi_sysvinit_all.deb
 
 EXPOSE 8080/tcp 8081/tcp 8443/tcp 8843/tcp 8880/tcp 3478/udp
 

--- a/unifi/5.4.16/Dockerfile
+++ b/unifi/5.4.16/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv C0A52C50
 
 RUN echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" >> /etc/apt/sources.list.d/200-unifi.list
 
-ENV UNIFI_INSTALL_URL=http://dl.ubnt.com/unifi/5.4.14/unifi_sysvinit_all.deb \
+ENV UNIFI_INSTALL_URL=http://dl.ubnt.com/unifi/5.4.16/unifi_sysvinit_all.deb \
     JAVA_MAX_HEAP_SIZE 512M
 
 # Install Supporting Packages

--- a/unifi/5.4.16/unifi_controller
+++ b/unifi/5.4.16/unifi_controller
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec /usr/bin/java -Xmx$JAVA_MAX_HEAP_SIZE -jar /usr/lib/unifi/lib/ace.jar $@


### PR DESCRIPTION
In order to properly install the correct versions of the unifi
controller this commit downloads the `.deb` install file for each
version. This commit also adds version 5.14.16 image to the repo. This
commit also sets the timezone on the ubuntu image.