### PR TITLE
Fix the install of openjdk-8-jre-headless

### DIFF
--- a/unifi/5.4.14/Dockerfile
+++ b/unifi/5.4.14/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -q update && \
     binutils \
     jsvc \
     openjdk-8-jre \
-    openjdk-8-jre-headlessi && \
+    openjdk-8-jre-headless && \
   apt-get -q clean && \
   rm -rf /var/lib/apt/lists/* && \
   curl -L -o unifi_sysvinit_all.deb $UNIFI_INSTALL_URL && \

--- a/unifi/5.4.15/Dockerfile
+++ b/unifi/5.4.15/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -q update && \
     binutils \
     jsvc \
     openjdk-8-jre \
-    openjdk-8-jre-headlessi && \
+    openjdk-8-jre-headless && \
   apt-get -q clean && \
   rm -rf /var/lib/apt/lists/* && \
   curl -L -o unifi_sysvinit_all.deb $UNIFI_INSTALL_URL && \

--- a/unifi/5.4.16/Dockerfile
+++ b/unifi/5.4.16/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -q update && \
     binutils \
     jsvc \
     openjdk-8-jre \
-    openjdk-8-jre-headlessi && \
+    openjdk-8-jre-headless && \
   apt-get -q clean && \
   rm -rf /var/lib/apt/lists/* && \
   curl -L -o unifi_sysvinit_all.deb $UNIFI_INSTALL_URL && \


### PR DESCRIPTION
This commit fixes the issue with the install of `openjdk-8-jre-headless`
by removing the trailing `i` left over from a vim session.