### PR TITLE
Upgrade alpine linux to 3.6

### DIFF
--- a/fast/Dockerfile
+++ b/fast/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 RUN apk add --update curl \
       ca-certificates \

--- a/vault/0.6.5/Dockerfile
+++ b/vault/0.6.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 RUN apk add --update unzip \

--- a/vault/0.6.5/Dockerfile.dev
+++ b/vault/0.6.5/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 RUN apk add --update unzip \

--- a/vault/0.7.0/Dockerfile
+++ b/vault/0.7.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 RUN apk add --update unzip \

--- a/vault/0.7.0/Dockerfile.dev
+++ b/vault/0.7.0/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 RUN apk add --update unzip \

--- a/vault/0.7.2/Dockerfile
+++ b/vault/0.7.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 RUN apk add --update unzip \

--- a/vault/0.7.2/Dockerfile.dev
+++ b/vault/0.7.2/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 RUN apk add --update unzip \


### PR DESCRIPTION
In order to have all the latest security updates, this commit updates
apline linux to 3.6.