### PR TITLE
Add ubuntu tag for laravel

### DIFF
--- a/laravel/alpine/Dockerfile
+++ b/laravel/alpine/Dockerfile
@@ -1,8 +1,8 @@
 FROM marcusmyers/composer:1.4.1
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
-RUN apk update \
-    && docker-php-ext-install gd mbstring mysqli pdo pdo_mysql mcrypt \
+RUN apk add --update ffmpeg chromium \
+    && docker-php-ext-install gd mbstring mysqli pdo pdo_mysql mcrypt curl zip exif dom json \
     && rm -rf /var/cache/apk/*
 
 RUN mkdir /app

--- a/laravel/ubuntu/Dockerfile
+++ b/laravel/ubuntu/Dockerfile
@@ -1,0 +1,31 @@
+FROM marcusmyers/ubuntu:16.04
+
+ADD https://getcomposer.org/download/1.4.2/composer.phar /usr/local/bin/
+
+RUN mv /usr/local/bin/composer.phar /usr/local/bin/composer && \
+    chmod +x /usr/local/bin/composer && \
+    curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
+    apt-get update && \
+    apt-get -f install && \
+    apt-get -y install php \
+      ffmpeg \
+      php-gd \
+      php-imagick \
+      php-mbstring \
+      mysql-client \
+      php-mcrypt \
+      php-curl \
+      php-zip \
+      php-exif \
+      php-dom \
+      php-xml \
+      php-pdo \
+      php-mysql \
+      php-json \
+      google-chrome-stable && \
+    apt-get -q clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /app
+WORKDIR /app


### PR DESCRIPTION
In order to use dusk with laravel, this commit adds an `ubuntu` tag
for the laravel image. The `latest` tag was moved to `alpine` as well as
adding the install ffmpeg and chromium in this pull request.