### PR TITLE
Add whalebrew tag for composer image

### DIFF
--- a/composer/whalebrew/Dockerfile
+++ b/composer/whalebrew/Dockerfile
@@ -1,0 +1,6 @@
+FROM marcusmyers/composer:1.4.2
+MAINTAINER Mark Myers <marcusmyers@gmail.com>
+
+LABEL io.whalebrew.name 'composer'
+
+ENTRYPOINT [ "/usr/local/bin/composer" ]


### PR DESCRIPTION
In order to use composer with whalebrew this commit adds a composer with
the whalebrew tag to function as a whalebrew image.