### PR TITLE
Add php 7.1 to laravel:ubuntu and fix laravel:alpine image

### DIFF
--- a/laravel/alpine/Dockerfile
+++ b/laravel/alpine/Dockerfile
@@ -1,8 +1,8 @@
-FROM marcusmyers/composer:1.4.1
+FROM marcusmyers/composer:1.4.2
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
-RUN apk add --update ffmpeg chromium \
-    && docker-php-ext-install gd mbstring mysqli pdo pdo_mysql mcrypt curl zip exif dom json \
+RUN apk add --update curl libcurl libxml2-dev libxml2 ffmpeg chromium mysql-client \
+    && docker-php-ext-install gd mbstring mysqli pdo pdo_mysql mcrypt zip exif dom json \
     && rm -rf /var/cache/apk/*
 
 RUN mkdir /app

--- a/laravel/ubuntu/Dockerfile
+++ b/laravel/ubuntu/Dockerfile
@@ -6,23 +6,24 @@ RUN mv /usr/local/bin/composer.phar /usr/local/bin/composer && \
     chmod +x /usr/local/bin/composer && \
     curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    apt-get update && \
+    add-apt-repository -y ppa:ondrej/php && \
+    apt-get update -y && \
     apt-get -f install && \
-    apt-get -y install php \
+    apt-get -y install php7.1 \
       ffmpeg \
-      php-gd \
-      php-imagick \
-      php-mbstring \
+      php7.1-gd \
+      php7.1-imagick \
+      php7.1-mbstring \
       mysql-client \
-      php-mcrypt \
-      php-curl \
-      php-zip \
-      php-exif \
-      php-dom \
-      php-xml \
-      php-pdo \
-      php-mysql \
-      php-json \
+      php7.1-mcrypt \
+      php7.1-curl \
+      php7.1-zip \
+      php7.1-exif \
+      php7.1-dom \
+      php7.1-xml \
+      php7.1-pdo \
+      php7.1-mysql \
+      php7.1-json \
       google-chrome-stable && \
     apt-get -q clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This commit fixes the `laravel:alpine` image to properly build.  This
commit also updates php to 7.1 in the ubuntu image.