### PR TITLE
Update composer to 1.5.1 in laravel images

### DIFF
--- a/laravel/alpine/Dockerfile
+++ b/laravel/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM marcusmyers/composer:1.4.2
+FROM marcusmyers/composer:1.5.1
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 RUN apk add --update curl libcurl libxml2-dev libxml2 ffmpeg chromium mysql-client \

--- a/laravel/ubuntu/Dockerfile
+++ b/laravel/ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 FROM marcusmyers/ubuntu:16.04
 
-ADD https://getcomposer.org/download/1.4.2/composer.phar /usr/local/bin/
+ADD https://getcomposer.org/download/1.5.1/composer.phar /usr/local/bin/
 
 RUN mv /usr/local/bin/composer.phar /usr/local/bin/composer && \
     chmod +x /usr/local/bin/composer && \


### PR DESCRIPTION
In order to run the latest version of `composer` in our laravel images,
this commit updates the composer version to `1.5.1`.