### PR TITLE
Move `export PATH` to `ENV`

### DIFF
--- a/jigsaw/Dockerfile
+++ b/jigsaw/Dockerfile
@@ -5,7 +5,8 @@ ENV COMPOSER_HOME=/composer
 
 RUN mkdir /composer \
     && mkdir /app \
-    && composer global require tightenco/jigsaw \
-    && export PATH=/composer/vendor/bin:$PATH
+    && composer global require tightenco/jigsaw
+
+ENV PATH="/composer/vendor/bin:${PATH}"
 
 WORKDIR /app


### PR DESCRIPTION
`export PATH` wasn't doing anything for me in this image, so none of my binaries were actually available via CLI. 

```[bash]
$ docker container run --rm -tdi --name jigsaw marcusmyers/jigsaw
$ docker container exec jigsaw jigsaw init .
rpc error: code = Unknown desc = oci runtime error: exec failed: container_linux.go:262: starting container process caused "exec: \"jigsaw\": executable file not found in $PATH"
$ docker container exec -ti jigsaw /bin/ash
/app # echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

Editing `$PATH` with an ENV layer seems to do the trick when I rebuild the image with the attached edits.