### PR TITLE
Add whalebrew LABEL

### DIFF
--- a/wp-cli/1.3.0/Dockerfile
+++ b/wp-cli/1.3.0/Dockerfile
@@ -11,4 +11,6 @@ RUN apk add --update tzdata freetype-dev libjpeg-turbo-dev libpng-dev libmcrypt-
   && apk del tzdata \
   && rm -rf /var/cache/apk/*
 
+LABEL io.whalebrew.name 'wp'
+
 ENTRYPOINT [ "/usr/local/bin/wp" ]


### PR DESCRIPTION
In order to use the `wp-cli` command with whalebrew, this commit adds
the correct `LABEL` to the `Dockerfile`.