### PR TITLE
Update phpunit image to use alpine and download latest

### DIFF
--- a/phpunit/Dockerfile
+++ b/phpunit/Dockerfile
@@ -1,5 +1,12 @@
-FROM phpunit/phpunit:6.0.6
+FROM php:7.0-alpine
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 LABEL io.whalebrew.name 'phpunit'
 LABEL io.whalebrew.config.working_dir '$PWD'
+
+ADD https://phar.phpunit.de/phpunit.phar /usr/local/bin/phpunit
+
+RUN chmod +x /usr/local/bin/phpunit
+
+ENTRYPOINT [ "/usr/local/bin/phpunit" ]
+CMD [ "--help" ]


### PR DESCRIPTION
In order to keep up to date with phpunit, this commit is a custom image
that will download the latest version of `phpunit` every time this
image is built.