### PR TITLE
Add new wp-cli version and use php 7.1 in phpunit image

### DIFF
--- a/phpunit/Dockerfile
+++ b/phpunit/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0-alpine
+FROM php:7.1-alpine
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 LABEL io.whalebrew.name 'phpunit'

--- a/wp-cli/1.4.0/Dockerfile
+++ b/wp-cli/1.4.0/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-alpine
 MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
-ENV VERSION=1.3.0
+ENV VERSION=1.4.0
 
-ADD https://github.com/wp-cli/wp-cli/releases/download/v${VERSION}/wp-cli-${VERSION.phar /usr/local/bin/wp
+ADD https://github.com/wp-cli/wp-cli/releases/download/v${VERSION}/wp-cli-${VERSION}.phar /usr/local/bin/wp
 
 RUN apk add --update tzdata freetype-dev libjpeg-turbo-dev libpng-dev libmcrypt-dev \
   && cp /usr/share/zoneinfo/America/New_York /etc/localtime \


### PR DESCRIPTION
This commit adds the new version of the `wp-cli` to the docker files and
updates `phpunit` to use php 7.1.