### PR TITLE
Fix the building of the wp-cli image

### DIFF
--- a/wp-cli/1.3.0/Dockerfile
+++ b/wp-cli/1.3.0/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Mark Myers <marcusmyers@gmail.com>
 
 ENV VERSION=1.3.0
 
-ADD https://github.com/wp-cli/wp-cli/releases/download/v${VERSION}/wp-cli-${VERSION.phar /usr/local/bin/wp
+ADD https://github.com/wp-cli/wp-cli/releases/download/v${VERSION}/wp-cli-${VERSION}.phar /usr/local/bin/wp
 
 RUN apk add --update tzdata freetype-dev libjpeg-turbo-dev libpng-dev libmcrypt-dev \
   && cp /usr/share/zoneinfo/America/New_York /etc/localtime \


### PR DESCRIPTION
This pull request fixes the building of the `wp-cli` to properly use the
environment variable for the version.